### PR TITLE
remove null checks for key/value in write_object_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.1.1] - 2024-02-21
+
+### Added
+- Added a check to prevent form serialization from supporting nested
+### Removed
+- Removed a null check for keys during the serialization process.
+
+### Changed
+
+
 ## [0.1.0] - 2024-02-21
 
 ### Added

--- a/kiota_serialization_form/_version.py
+++ b/kiota_serialization_form/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = '0.1.0'
+VERSION: str = '0.1.1'

--- a/kiota_serialization_form/form_serialization_writer.py
+++ b/kiota_serialization_form/form_serialization_writer.py
@@ -188,7 +188,7 @@ class FormSerializationWriter(SerializationWriter):
         """
         temp_writer = self._create_new_writer()
 
-        if  value is not None:
+        if value is not None:
             self._serialize_value(temp_writer, value)
 
         for additional_value in filter(lambda x: x is not None, additional_values_to_merge):

--- a/kiota_serialization_form/form_serialization_writer.py
+++ b/kiota_serialization_form/form_serialization_writer.py
@@ -186,24 +186,23 @@ class FormSerializationWriter(SerializationWriter):
             additional_values_to_merge (tuple[Parsable]): The additional values to merge to the
             main value when serializing an intersection wrapper.
         """
-        if key and (value or additional_values_to_merge):
-            temp_writer = self._create_new_writer()
+        temp_writer = self._create_new_writer()
 
-            if value:
-                self._serialize_value(temp_writer, value)
+        if  value is not None:
+            self._serialize_value(temp_writer, value)
 
-            if additional_values_to_merge:
-                for additional_value in filter(lambda x: x is not None, additional_values_to_merge):
-                    self._serialize_value(temp_writer, additional_value)
-                    if on_after := self.on_after_object_serialization:
-                        on_after(additional_value)
+        for additional_value in filter(lambda x: x is not None, additional_values_to_merge):
+            self._serialize_value(temp_writer, additional_value)
+            if on_after := self.on_after_object_serialization:
+                on_after(additional_value)
 
-            if value and self._on_after_object_serialization:
-                self._on_after_object_serialization(value)
+        if value and self._on_after_object_serialization:
+            self._on_after_object_serialization(value)
 
-            if len(self.writer) > 0:
-                self.writer += "&"
-            self.writer += f"{quote_plus(key.strip())}={temp_writer.writer}"
+        if len(self.writer) > 0:
+            self.writer += "&"
+        self.writer += f"{quote_plus(key.strip()) if key is not None else ''}={temp_writer.writer}"
+
 
     def write_null_value(self, key: Optional[str]) -> None:
         """Writes a null value for the specified key.

--- a/kiota_serialization_form/form_serialization_writer.py
+++ b/kiota_serialization_form/form_serialization_writer.py
@@ -18,6 +18,7 @@ class FormSerializationWriter(SerializationWriter):
 
     def __init__(self) -> None:
         self.writer: str = ""
+        self.depth = 0
 
         self._on_start_object_serialization: Optional[Callable[[Parsable, SerializationWriter],
                                                                None]] = None
@@ -186,6 +187,9 @@ class FormSerializationWriter(SerializationWriter):
             additional_values_to_merge (tuple[Parsable]): The additional values to merge to the
             main value when serializing an intersection wrapper.
         """
+        if self.depth > 0:
+            raise Exception("Form serialization does not support nested objects.")
+        self.depth += 1
         temp_writer = self._create_new_writer()
 
         if value is not None:
@@ -202,6 +206,7 @@ class FormSerializationWriter(SerializationWriter):
         if len(self.writer) > 0:
             self.writer += "&"
         self.writer += f"{quote_plus(key.strip()) if key is not None else ''}={temp_writer.writer}"
+        self.depth -= 1
 
 
     def write_null_value(self, key: Optional[str]) -> None:

--- a/kiota_serialization_form/form_serialization_writer.py
+++ b/kiota_serialization_form/form_serialization_writer.py
@@ -208,7 +208,6 @@ class FormSerializationWriter(SerializationWriter):
         self.writer += f"{quote_plus(key.strip()) if key is not None else ''}={temp_writer.writer}"
         self.depth -= 1
 
-
     def write_null_value(self, key: Optional[str]) -> None:
         """Writes a null value for the specified key.
         Args:


### PR DESCRIPTION

Fixes https://github.com/microsoft/kiota-serialization-form-python/issues/14

## Overview


Brief description of what this PR does, and why it is needed.

## Related Issue

Fixes # (issue)

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output